### PR TITLE
Add missing #pragma once to two header files

### DIFF
--- a/Include/kenshi/CharMovement.h
+++ b/Include/kenshi/CharMovement.h
@@ -1,3 +1,4 @@
+#pragma once
 
 #include <ogre/OgreMemoryAllocatorConfig.h>
 #include <ogre/OgreVector3.h>

--- a/Include/kenshi/gui/DataPanelLine.h
+++ b/Include/kenshi/gui/DataPanelLine.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <mygui/MyGUI_TextBox.h>
 #include <kenshi/util/StringPair.h>
 #include <kenshi/util/lektor.h>

--- a/Include/kenshi/gui/MainBarGUI.h
+++ b/Include/kenshi/gui/MainBarGUI.h
@@ -12,6 +12,7 @@ class ToolTip;
 class DatapanelGUI;
 class PortraitMainItemBox;
 class DatapanelGUI;
+class MainBarGUI;
 
 // TODO move?
 class MainTabPortraitPlatoon : public Ogre::GeneralAllocatedObject


### PR DESCRIPTION
These headers lacked include guards, which could allow multiple inclusion during compilation. Add #pragma once for consistency with the rest of the codebase.