### PR TITLE
Add pragma once to FarmBuilding.h

### DIFF
--- a/Include/kenshi/Building/FarmBuilding.h
+++ b/Include/kenshi/Building/FarmBuilding.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "ProductionBuilding.h"
 
 #include <ogre/OgreMesh.h>


### PR DESCRIPTION
Add missing #pragma once include guard to FarmBuilding.h in order to prevent multiple include/redefinition errors.