### PR TITLE
Fix BaseLayout dllimport declaration

### DIFF
--- a/Include/mygui/common/baselayout/BaseLayout.h
+++ b/Include/mygui/common/baselayout/BaseLayout.h
@@ -14,7 +14,7 @@
 namespace wraps
 {
 
-	__declspec(dllimport) class BaseLayout
+	class __declspec(dllimport) BaseLayout
 	{
 	// HACK BFRIZZ make everything public because it's an internal, statically-linked class
 	public:


### PR DESCRIPTION
# Problem

Trying to link KenshiLib in its current state will not add functions from wraps::BaseLayout to the new DLL's import table.

While this syntax is apparently acceptable in certain compiler versions, you'll notice that trying to build a DLL while including BaseLayout.h in its current state gives the following warning:

`warning C4091: '__declspec(dllimport)' : ignored on left of 'wraps::BaseLayout'
 when no variable is declared [...]`

The DLL will still build and function for the most part, but on attempting to load the DLL with a hook on something like wraps::BaseLayout::initialise, KenshiLib will hit this assert:

`Error 11.377 KenshiLib: Assertion failed: Incorrect address in KenshiLib::GetRealAddress()
The address you provided appears to be in your own module, try enabling "whole program optimization" in your compilation settings.
Function address: example.dll+0x11c0
KenshiLib::GetRealAddress() should only be called on KensihLib-exported function stubs with addresses in KenshiLib.dll in Source\core\Functions.cpp line: 144`

The problem can be easily verified by building two identical DLL's that both place a hook on wraps::BaseLayout::initialise with the only difference being the change suggested for BaseLayout.h.

Using Dependencies(x64) to view the two DLL's import/export tables will show that the one built with the current format does not have wraps::BaseLayout::initialise in its list of imported functions. This explains the assert. 

# Fix

Change the class BaseLayout declaration from `__declspec(dllimport) class BaseLayout {}` to `class __declspec(dllimport) BaseLayout {}`

This ensures the compiler/linker recognizes that BaseLayout is a class that exists in another DLL and must be imported. Doing so allows for functions within class BaseLayout to be hooked without hitting the assert